### PR TITLE
completed base wave spawner, deleted pathfollow2D

### DIFF
--- a/halfling-tower-defence/Enemyprogression.cs
+++ b/halfling-tower-defence/Enemyprogression.cs
@@ -7,12 +7,14 @@ public partial class Enemyprogression : PathFollow2D
 	public float Speed = 300f;
 	private bool Killed = false;
 	
+	
 	[Signal]
 	public delegate void KillEventHandler();
 	
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready()
 	{
+		
 	}
 
 	// Called every frame. 'delta' is the elapsed time since the previous frame.
@@ -27,7 +29,6 @@ public partial class Enemyprogression : PathFollow2D
 		else if (ProgressRatio == 1.0f && Killed == false)
 			{
 				GD.Print("finished");
-				EmitSignal(SignalName.Kill);
 				Killed = !Killed;
 			}
 	}

--- a/halfling-tower-defence/Scenes/Map.tscn
+++ b/halfling-tower-defence/Scenes/Map.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=7 format=3 uid="uid://dl7uj1tskwnmn"]
+[gd_scene load_steps=6 format=3 uid="uid://dl7uj1tskwnmn"]
 
 [ext_resource type="Texture2D" uid="uid://bjestqjcsf1ja" path="res://Assets/waterB_spritesheet.png" id="1_j2wod"]
-[ext_resource type="PackedScene" uid="uid://dwugkhwa7fhp2" path="res://Scenes/test_enemy.tscn" id="2_26yhd"]
-[ext_resource type="Script" uid="uid://3livamp0jxv1" path="res://Enemyprogression.cs" id="2_p3ir5"]
+[ext_resource type="PackedScene" uid="uid://eqi1kpxcfasl" path="res://Scenes/spawner.tscn" id="4_myvm1"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_v1qfn"]
 texture = ExtResource("1_j2wod")
@@ -1017,10 +1016,4 @@ zoom = Vector2(1.4, 1.15)
 [node name="Path2D" type="Path2D" parent="."]
 curve = SubResource("Curve2D_26yhd")
 
-[node name="PathFollow2D" type="PathFollow2D" parent="Path2D"]
-position = Vector2(-384, -8)
-rotates = false
-loop = false
-script = ExtResource("2_p3ir5")
-
-[node name="test_enemy" parent="Path2D/PathFollow2D" instance=ExtResource("2_26yhd")]
+[node name="Spawner" parent="." instance=ExtResource("4_myvm1")]

--- a/halfling-tower-defence/Scenes/Spawner.cs
+++ b/halfling-tower-defence/Scenes/Spawner.cs
@@ -1,0 +1,41 @@
+using Godot;
+using System;
+
+public partial class Spawner : Node2D
+{
+	private Timer timer;
+	
+	
+	private PackedScene test_enemy = GD.Load<PackedScene>("res://Scenes/test_enemy.tscn");
+	
+	// Called when the node enters the scene tree for the first time.
+	public override void _Ready()
+	{
+		timer = GetNode<Timer>("Timer");
+		timer.Start();
+		timer.Timeout += _on_timer_timeout;
+		
+	}
+
+	// Called every frame. 'delta' is the elapsed time since the previous frame.
+	public override void _Process(double delta)
+	{
+		
+	}
+	
+	private void _on_timer_timeout()
+	{
+		GD.Print("timeout");
+		
+		var enemypath = GetNode<Path2D>("/root/map/Path2D");
+		var test_enemy_spawn = test_enemy.Instantiate<CharacterBody2D>();
+		
+		var new_enemypath = new PathFollow2D();
+		new_enemypath.ProgressRatio = 0f;
+		new_enemypath.Loop = false;
+		new_enemypath.Rotates = false;
+		enemypath.AddChild(new_enemypath);
+		new_enemypath.AddChild(test_enemy_spawn);
+	}
+	
+}

--- a/halfling-tower-defence/Scenes/Spawner.cs.uid
+++ b/halfling-tower-defence/Scenes/Spawner.cs.uid
@@ -1,0 +1,1 @@
+uid://csyoy2pssjs1x

--- a/halfling-tower-defence/Scenes/map.tscn
+++ b/halfling-tower-defence/Scenes/map.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=7 format=3 uid="uid://dl7uj1tskwnmn"]
+[gd_scene load_steps=6 format=3 uid="uid://dl7uj1tskwnmn"]
 
 [ext_resource type="Texture2D" uid="uid://bjestqjcsf1ja" path="res://Assets/waterB_spritesheet.png" id="1_j2wod"]
-[ext_resource type="PackedScene" uid="uid://dwugkhwa7fhp2" path="res://Scenes/test_enemy.tscn" id="2_26yhd"]
-[ext_resource type="Script" uid="uid://3livamp0jxv1" path="res://Enemyprogression.cs" id="2_p3ir5"]
+[ext_resource type="PackedScene" uid="uid://eqi1kpxcfasl" path="res://Scenes/spawner.tscn" id="4_myvm1"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_v1qfn"]
 texture = ExtResource("1_j2wod")
@@ -1017,10 +1016,4 @@ zoom = Vector2(1.4, 1.15)
 [node name="Path2D" type="Path2D" parent="."]
 curve = SubResource("Curve2D_26yhd")
 
-[node name="PathFollow2D" type="PathFollow2D" parent="Path2D"]
-position = Vector2(-384, -8)
-rotates = false
-loop = false
-script = ExtResource("2_p3ir5")
-
-[node name="test_enemy" parent="Path2D/PathFollow2D" instance=ExtResource("2_26yhd")]
+[node name="Spawner" parent="." instance=ExtResource("4_myvm1")]

--- a/halfling-tower-defence/Scenes/spawner.tscn
+++ b/halfling-tower-defence/Scenes/spawner.tscn
@@ -1,0 +1,9 @@
+[gd_scene load_steps=2 format=3 uid="uid://eqi1kpxcfasl"]
+
+[ext_resource type="Script" uid="uid://csyoy2pssjs1x" path="res://Scenes/Spawner.cs" id="1_2bop2"]
+
+[node name="Spawner" type="Node2D"]
+script = ExtResource("1_2bop2")
+
+[node name="Timer" type="Timer" parent="."]
+wait_time = 2.5

--- a/halfling-tower-defence/Scenes/test_enemy.tscn
+++ b/halfling-tower-defence/Scenes/test_enemy.tscn
@@ -1,20 +1,18 @@
 [gd_scene load_steps=4 format=3 uid="uid://dwugkhwa7fhp2"]
 
 [ext_resource type="Script" uid="uid://dwq1ci8gi6q6g" path="res://TestEnemy.cs" id="1_bs22l"]
-[ext_resource type="Texture2D" uid="uid://byfkh61fbpj3" path="res://icon.svg" id="1_r1vdb"]
+[ext_resource type="Texture2D" uid="uid://byfkh61fbpj3" path="res://Assets/icon.svg" id="1_r1vdb"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_r1vdb"]
 size = Vector2(130, 128)
 
-[node name="test_enemy" type="Node2D"]
+[node name="test_enemy" type="CharacterBody2D"]
 script = ExtResource("1_bs22l")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 position = Vector2(2, 0)
 texture = ExtResource("1_r1vdb")
 
-[node name="Area2D" type="Area2D" parent="."]
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 position = Vector2(1, 0)
 shape = SubResource("RectangleShape2D_r1vdb")

--- a/halfling-tower-defence/TestEnemy.cs
+++ b/halfling-tower-defence/TestEnemy.cs
@@ -1,20 +1,38 @@
 using Godot;
 using System;
 
-public partial class TestEnemy : Node2D
+public partial class TestEnemy : CharacterBody2D
 {
+	//assigns pathprogress as a variable, but no value
+	private PathFollow2D pathprogress;
+	
+	
+	
 	// Called when the node enters the scene tree for the first time.
 	public override void _Ready()
 	{
-		var kill = GetNode<Enemyprogression>("/root/map/Path2D/PathFollow2D");
 		
-		kill.Kill += OnKill;
+		
+		
+		//gives pathprogress a value
+		pathprogress = GetParent<PathFollow2D>();
 	}
 
 	// Called every frame. 'delta' is the elapsed time since the previous frame.
 	public override void _Process(double delta)
 	{
 		
+		
+		if (pathprogress.ProgressRatio < 1.0f)
+			{
+				pathprogress.ProgressRatio += .001f;
+			}
+		else if (pathprogress.ProgressRatio == 1.0f)
+			{
+				GD.Print("freed");
+				QueueFree();
+			}
+			
 	}
 	
 	private void OnKill()


### PR DESCRIPTION
The spawner only spawns the test enemy every time the timer runs out, it still needs to be set up to a signal for each wave.